### PR TITLE
Fix: correct using start and end arguments for newGetNewsCommand

### DIFF
--- a/xtb/get_news.go
+++ b/xtb/get_news.go
@@ -38,7 +38,7 @@ func NewGetNewsCommand(end, start time.Time) *Command {
 		Command: "getNews",
 		Arguments: &getNewsRequest{
 			End:   Time(end),
-			Start: Time(end),
+			Start: Time(start),
 		},
 	}
 }


### PR DESCRIPTION
Using a start argument of a function as start argument for xtb API